### PR TITLE
added user prefix required when loading from galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,4 +13,4 @@ galaxy_info:
   categories:
     - system
 dependencies:
- - config_encoder_filters
+ - jtyr.config_encoder_filters


### PR DESCRIPTION
your user prefix is requirement on galaxy as without it ansible can't find jtyr.config_encoder_filters package